### PR TITLE
Feature/volunteer-columns

### DIFF
--- a/app/Actions/GetAvailableUsersForShift.php
+++ b/app/Actions/GetAvailableUsersForShift.php
@@ -29,7 +29,7 @@ class GetAvailableUsersForShift
 
         return User::query()
             ->distinct()
-            ->select(['users.*', 'last_shift_date', 'last_shift_start_time'])
+            ->select(['users.*', 'last_shift_date', 'last_shift_start_time', 'last_location_name'])
             ->when($this->settings->enableUserAvailability, fn(Builder $query) => $query
                 ->addSelect(['filled_sundays', 'filled_mondays', 'filled_tuesdays', 'filled_wednesdays', 'filled_thursdays', 'filled_fridays', 'filled_saturdays'])
                 ->addSelect(['num_sundays', 'num_mondays', 'num_tuesdays', 'num_wednesdays', 'num_thursdays', 'num_fridays', 'num_saturdays', 'comments'])
@@ -41,6 +41,7 @@ class GetAvailableUsersForShift
                     ->select(['user_id'])
                     ->selectRaw('MAX(shift_date) as last_shift_date')
                     ->selectRaw('MAX(shifts.start_time) as last_shift_start_time')
+                    ->selectRaw("SUBSTRING_INDEX(GROUP_CONCAT(locations.name ORDER BY shift_date DESC, shifts.start_time DESC SEPARATOR '||'), '||', 1) as last_location_name")
                     ->from('shift_user')
                     ->join(table: 'shifts', first: fn(JoinClause $join) => $join
                         ->on('shift_user.shift_id', '=', 'shifts.id')

--- a/app/Data/ExtendedUserData.php
+++ b/app/Data/ExtendedUserData.php
@@ -30,6 +30,7 @@ class ExtendedUserData extends Data
         public string|Optional $shift_date,
         public string|Optional $last_shift_date,
         public string|Optional $last_shift_start_time,
+        public string|Optional $last_location_name,
         public int|Optional $num_sundays,
         public int|Optional $num_mondays,
         public int|Optional $num_tuesdays,

--- a/resources/js/Components/UserTableOptionalFields.vue
+++ b/resources/js/Components/UserTableOptionalFields.vue
@@ -1,16 +1,20 @@
 <script setup lang="ts">
 import { templateRef } from "@vueuse/core";
-import { computed } from "vue";
-import { useGlobalState } from "@/store";
+import { computed, inject } from "vue";
+import { useGlobalState, columnFilterOrder } from "@/store";
+import { EnableUserAvailability } from "@/Utils/provide-inject-keys";
 import type { LocalStore } from "@/store";
 
 const state = useGlobalState();
+const enableUserAvailability = inject(EnableUserAvailability);
 
-const options = computed(() => Object.entries(state.value.columnFilters).map(([key, value]) => ({
-  key,
-  name: value.label,
-  value: value.value,
-})));
+const options = computed(() => columnFilterOrder
+  .filter((key) => enableUserAvailability || key !== "weeksPerMonth")
+  .map((key) => ({
+    key,
+    name: state.value.columnFilters[key].label,
+    value: state.value.columnFilters[key].value,
+  })));
 
 const model = computed({
   get: () => options.value.filter((value) => value.value).map((value) => ({ ...value })),

--- a/resources/js/Pages/Admin/Dashboard/UserTable.vue
+++ b/resources/js/Pages/Admin/Dashboard/UserTable.vue
@@ -115,6 +115,20 @@ const tableHeaders = computed(() => {
       sortable: false,
     });
   }
+  if (columnFilters.value.lastLocation.value) {
+    headers.push({
+      text: "Last Location",
+      value: "lastLocation",
+      sortable: true,
+    });
+  }
+  if (columnFilters.value.comments.value) {
+    headers.push({
+      text: "Comments",
+      value: "comments",
+      sortable: true,
+    });
+  }
   headers.push({
     text: "Last Shift",
     value: "lastShift",
@@ -161,7 +175,7 @@ const tableRows = computed(() => {
       id: volunteer.id,
       name: `${prefix} ${volunteer.name}`,
       gender: volunteer.gender,
-      comment: volunteer.availability_comments,
+      comments: volunteer.availability_comments,
       lastShift: volunteer.last_shift_date ? volunteer.last_shift_date : null,
       lastShiftTime: volunteer.last_shift_start_time ? volunteer.last_shift_start_time : null,
       filledShifts: calcShiftPercentage(daysAlreadyRostered, daysAvailable),
@@ -171,6 +185,7 @@ const tableRows = computed(() => {
       maritalStatus: volunteer.marital_status,
       birthYear: volunteer.birth_year,
       mobilePhone: volunteer.mobile_phone,
+      lastLocation: volunteer.last_location_name ?? null,
       daysAlreadyRostered,
       daysAvailable,
     };
@@ -309,11 +324,16 @@ const hasDaysAvailable = (daysAvailable) => Object.values(daysAvailable).some((d
         {{ header.text }}
       </template>
 
-      <template #item-name="{ name, comment }">
+      <template #item-name="{ name, comments }">
         {{ name }}
-        <div class="ms-0.5 text-xs italic text-neutral-900 dark:text-neutral-200">
-          <div>{{ comment }}</div>
+        <div v-if="!columnFilters.comments.value && comments"
+             class="ms-0.5 text-xs italic text-neutral-900 dark:text-neutral-200">
+          <div>{{ comments }}</div>
         </div>
+      </template>
+
+      <template #item-comments="{ comments }">
+        <span class="text-xs italic text-neutral-900 dark:text-neutral-200">{{ comments }}</span>
       </template>
 
       <template #item-responsibleBrother="{ responsibleBrother }">
@@ -335,6 +355,10 @@ const hasDaysAvailable = (daysAvailable) => Object.values(daysAvailable).some((d
 
       <template #item-birthYear="{ birthYear }">
         {{ birthYear }}
+      </template>
+
+      <template #item-lastLocation="{ lastLocation }">
+        {{ lastLocation ?? "Never" }}
       </template>
 
       <template #item-mobilePhone="{ mobilePhone }">

--- a/resources/js/Pages/Admin/Dashboard/UserTable.vue
+++ b/resources/js/Pages/Admin/Dashboard/UserTable.vue
@@ -3,6 +3,7 @@ import { format, parse } from "date-fns";
 import { Menu as VMenu } from "floating-vue";
 import { computed, inject, ref, watchEffect } from "vue";
 import DataTable from "@/Components/DataTable.vue";
+import { numberOfWeeks } from "@/Composables/useAvailabilityActions";
 import QuestionCircle from "@/Components/Icons/QuestionCircle.vue";
 import useToast from "@/Composables/useToast";
 import FilledShiftsIndicator from "@/Pages/Admin/Dashboard/FilledShiftsIndicator.vue";
@@ -51,6 +52,8 @@ const state = useGlobalState();
 const columnFilters = computed(() => state.value["columnFilters"]);
 const enableUserAvailability = inject(EnableUserAvailability);
 const volunteers = ref<App.Data.ExtendedUserData[]>([]);
+
+const shiftDayKey = computed(() => format(props.date, "EEEE").toLowerCase());
 
 const tableHeaders = computed(() => {
   const headers = [
@@ -115,6 +118,11 @@ const tableHeaders = computed(() => {
       sortable: false,
     });
   }
+  headers.push({
+    text: "Last Shift",
+    value: "lastShift",
+    sortable: true,
+  });
   if (columnFilters.value.lastLocation.value) {
     headers.push({
       text: "Last Location",
@@ -129,11 +137,13 @@ const tableHeaders = computed(() => {
       sortable: true,
     });
   }
-  headers.push({
-    text: "Last Shift",
-    value: "lastShift",
-    sortable: true,
-  });
+  if (enableUserAvailability && columnFilters.value.weeksPerMonth.value) {
+    headers.push({
+      text: "Weeks/Month",
+      value: "weeksPerMonth",
+      sortable: true,
+    });
+  }
   if (enableUserAvailability) {
     headers.push({
       text: "Availability",
@@ -171,6 +181,9 @@ const tableRows = computed(() => {
       saturday: (volunteer.filled_saturdays < daysAvailable.saturday ? volunteer.filled_saturdays : daysAvailable.saturday) || 0,
     };
 
+    const numDaysKey = `num_${shiftDayKey.value}s` as keyof App.Data.ExtendedUserData;
+    const weeksPerMonth = (volunteer[numDaysKey] as number | undefined) ?? 0;
+
     return {
       id: volunteer.id,
       name: `${prefix} ${volunteer.name}`,
@@ -179,6 +192,7 @@ const tableRows = computed(() => {
       lastShift: volunteer.last_shift_date ? volunteer.last_shift_date : null,
       lastShiftTime: volunteer.last_shift_start_time ? volunteer.last_shift_start_time : null,
       filledShifts: calcShiftPercentage(daysAlreadyRostered, daysAvailable),
+      weeksPerMonth,
       responsibleBrother: volunteer.responsible_brother,
       appointment: volunteer.appointment,
       servingAs: volunteer.serving_as,
@@ -379,6 +393,11 @@ const hasDaysAvailable = (daysAvailable) => Object.values(daysAvailable).some((d
 
       <template #item-lastShift="{ lastShift, lastShiftTime }">
         {{ formatShiftDate(lastShift, lastShiftTime) }}
+      </template>
+
+      <template #item-weeksPerMonth="{ weeksPerMonth }">
+        <span v-if="weeksPerMonth > 0">{{ numberOfWeeks[weeksPerMonth as keyof typeof numberOfWeeks] }}</span>
+        <span v-else class="italic text-gray-500">Not set</span>
       </template>
 
       <template #item-filledShifts="{ daysAlreadyRostered, daysAvailable, filledShifts }">

--- a/resources/js/store.ts
+++ b/resources/js/store.ts
@@ -8,6 +8,8 @@ enum Labels {
   BirthYear = "Birth Year",
   ResponsibleBrother = "Is Responsible Bro?",
   MobilePhone = "Phone",
+  LastLocation = "Last Location",
+  Comments = "Comments",
 }
 
 export type LocalStore = {
@@ -20,6 +22,8 @@ export type LocalStore = {
     birthYear: { label: Labels.BirthYear; value: boolean };
     responsibleBrother: { label: Labels.ResponsibleBrother; value: boolean };
     mobilePhone: { label: Labels.MobilePhone; value: boolean };
+    lastLocation: { label: Labels.LastLocation; value: boolean };
+    comments: { label: Labels.Comments; value: boolean };
   };
   shiftView: "list" | "calendar";
 };
@@ -35,15 +39,33 @@ const defaults: LocalStore = {
     birthYear: { label: Labels.BirthYear, value: false },
     responsibleBrother: { label: Labels.ResponsibleBrother, value: false },
     mobilePhone: { label: Labels.MobilePhone, value: false },
+    lastLocation: { label: Labels.LastLocation, value: false },
+    comments: { label: Labels.Comments, value: false },
   },
   shiftView: "calendar",
 };
 
 export const useGlobalState = createGlobalState(
-  () => useStorage<LocalStore>(
-    "cart-scheduler-store",
-    defaults,
-    localStorage,
-    { mergeDefaults: true },
-  ),
+  () => {
+    const storage = useStorage<LocalStore>(
+      "cart-scheduler-store",
+      defaults,
+      localStorage,
+      { mergeDefaults: true },
+    );
+
+    // mergeDefaults is shallow; backfill new keys and label changes from older localStorage data
+    const storedFilters = storage.value.columnFilters ?? {};
+    storage.value.columnFilters = Object.fromEntries(
+      Object.entries(defaults.columnFilters).map(([key, defaultFilter]) => [
+        key,
+        {
+          ...defaultFilter,
+          value: storedFilters[key as keyof typeof storedFilters]?.value ?? defaultFilter.value,
+        },
+      ]),
+    ) as LocalStore["columnFilters"];
+
+    return storage;
+  },
 );

--- a/resources/js/store.ts
+++ b/resources/js/store.ts
@@ -8,6 +8,7 @@ enum Labels {
   BirthYear = "Birth Year",
   ResponsibleBrother = "Is Responsible Bro?",
   MobilePhone = "Phone",
+  WeeksPerMonth = "Weeks/Month",
   LastLocation = "Last Location",
   Comments = "Comments",
 }
@@ -15,32 +16,48 @@ enum Labels {
 export type LocalStore = {
   dismissedAvailabilityOn?: Date;
   columnFilters: {
+    responsibleBrother: { label: Labels.ResponsibleBrother; value: boolean };
     gender: { label: Labels.Gender; value: boolean };
     appointment: { label: Labels.Appointment; value: boolean };
     servingAs: { label: Labels.ServingAs; value: boolean };
     maritalStatus: { label: Labels.MaritalStatus; value: boolean };
     birthYear: { label: Labels.BirthYear; value: boolean };
-    responsibleBrother: { label: Labels.ResponsibleBrother; value: boolean };
     mobilePhone: { label: Labels.MobilePhone; value: boolean };
     lastLocation: { label: Labels.LastLocation; value: boolean };
     comments: { label: Labels.Comments; value: boolean };
+    weeksPerMonth: { label: Labels.WeeksPerMonth; value: boolean };
   };
   shiftView: "list" | "calendar";
 };
+
+/** Matches optional column order in UserTable.vue */
+export const columnFilterOrder = [
+  "responsibleBrother",
+  "gender",
+  "appointment",
+  "servingAs",
+  "maritalStatus",
+  "birthYear",
+  "mobilePhone",
+  "lastLocation",
+  "comments",
+  "weeksPerMonth",
+] as const satisfies readonly (keyof LocalStore["columnFilters"])[];
 
 const defaults: LocalStore = {
   dismissedAvailabilityOn: undefined,
   // used to filter admin volunteer rostering table
   columnFilters: {
+    responsibleBrother: { label: Labels.ResponsibleBrother, value: false },
     gender: { label: Labels.Gender, value: false },
     appointment: { label: Labels.Appointment, value: false },
     servingAs: { label: Labels.ServingAs, value: false },
     maritalStatus: { label: Labels.MaritalStatus, value: false },
     birthYear: { label: Labels.BirthYear, value: false },
-    responsibleBrother: { label: Labels.ResponsibleBrother, value: false },
     mobilePhone: { label: Labels.MobilePhone, value: false },
     lastLocation: { label: Labels.LastLocation, value: false },
     comments: { label: Labels.Comments, value: false },
+    weeksPerMonth: { label: Labels.WeeksPerMonth, value: false },
   },
   shiftView: "calendar",
 };

--- a/resources/js/types/laravel.d.ts
+++ b/resources/js/types/laravel.d.ts
@@ -46,6 +46,7 @@ declare namespace App.Data {
     shift_date?: string;
     last_shift_date?: string;
     last_shift_start_time?: string;
+    last_location_name?: string;
     num_sundays?: number;
     num_mondays?: number;
     num_tuesdays?: number;


### PR DESCRIPTION
Add sortable columns to Volunteer selection table

- Last Location
- Comment
- Weeks/Month — shows the volunteer's regular availability (num_<day>s) for the selected shift's day of week, displayed using the same week labels as the availability form and sortable on the underlying numeric value. The column is only available when user availability is enabled.

All columns are exposed as an optional column under "Extra Columns".

Introduced a shared columnFilterOrder in the store so the dropdown order stays in sync with the table column order.


This replaces previous PR: https://github.com/pixelated-au/CartScheduler/pull/14