### PR TITLE
Configurable confirmation for removing shift reservations

### DIFF
--- a/app/Http/Controllers/UpdateGeneralSettingsController.php
+++ b/app/Http/Controllers/UpdateGeneralSettingsController.php
@@ -13,11 +13,13 @@ class UpdateGeneralSettingsController extends Controller
 
     public function __invoke(UpdateGeneralSettingsRequest $request)
     {
-        $this->settings->siteName                  = $request->input('siteName');
-        $this->settings->systemShiftStartHour      = $request->input('systemShiftStartHour');
-        $this->settings->systemShiftEndHour        = $request->input('systemShiftEndHour');
-        $this->settings->enableUserAvailability    = $request->input('enableUserAvailability');
-        $this->settings->enableUserLocationChoices = $request->input('enableUserLocationChoices');
+        $this->settings->siteName                   = $request->input('siteName');
+        $this->settings->systemShiftStartHour       = $request->input('systemShiftStartHour');
+        $this->settings->systemShiftEndHour         = $request->input('systemShiftEndHour');
+        $this->settings->enableUserAvailability     = $request->boolean('enableUserAvailability');
+        $this->settings->enableUserLocationChoices  = $request->boolean('enableUserLocationChoices');
+        $this->settings->enableShiftRemoveConfirm   = $request->boolean('enableShiftRemoveConfirm');
+        $this->settings->shiftRemoveConfirmMessage  = $request->string('shiftRemoveConfirmMessage')->toString();
         $this->settings->save();
 
         return to_route('admin.settings');

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -86,6 +86,10 @@ class HandleInertiaRequests extends Middleware
             $custom['enableUserLocationChoices'] = true;
         }
 
+        if ($this->settings->enableShiftRemoveConfirm) {
+            $custom['shiftRemoveConfirmMessage'] = $this->settings->shiftRemoveConfirmMessage;
+        }
+
         if ($user?->is_unrestricted) {
             $custom['isUnrestricted'] = true;
         }

--- a/app/Http/Requests/UpdateGeneralSettingsRequest.php
+++ b/app/Http/Requests/UpdateGeneralSettingsRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UpdateGeneralSettingsRequest extends FormRequest
 {
@@ -18,6 +19,13 @@ class UpdateGeneralSettingsRequest extends FormRequest
             // TODO: add test for lt and gt rules
             'systemShiftStartHour' => ['required', 'integer', 'min:0', 'max:23', 'lt:systemShiftEndHour'],
             'systemShiftEndHour' => ['required', 'integer', 'min:0', 'max:23', 'gt:systemShiftStartHour'],
+            'enableShiftRemoveConfirm' => ['required', 'boolean'],
+            'shiftRemoveConfirmMessage' => [
+                Rule::requiredIf($this->boolean('enableShiftRemoveConfirm')),
+                'nullable',
+                'string',
+                'max:200',
+            ],
         ];
     }
 

--- a/app/Settings/GeneralSettings.php
+++ b/app/Settings/GeneralSettings.php
@@ -18,6 +18,8 @@ class GeneralSettings extends Settings
     public bool $enableUserAvailability;
     /** @var bool allow the volunteer to choose which locations they wish to be rostered onto */
     public bool $enableUserLocationChoices;
+    public bool $enableShiftRemoveConfirm;
+    public string $shiftRemoveConfirmMessage;
 
     public static function group(): string
     {

--- a/database/settings/2026_06_30_065105_update_general_settings_shift_remove_confirmation.php
+++ b/database/settings/2026_06_30_065105_update_general_settings_shift_remove_confirmation.php
@@ -1,0 +1,15 @@
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsBlueprint;
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class extends SettingsMigration
+{
+    public function up(): void
+    {
+        $this->migrator->inGroup('general', function (SettingsBlueprint $blueprint): void {
+            $blueprint->add('enableShiftRemoveConfirm', false);
+            $blueprint->add('shiftRemoveConfirmMessage', '');
+        });
+    }
+};

--- a/resources/js/Jetstream/InputError.vue
+++ b/resources/js/Jetstream/InputError.vue
@@ -3,7 +3,7 @@ import { promiseTimeout } from "@vueuse/core";
 import { computed, watch, ref } from "vue";
 
 const { message } = defineProps<{
-  message?: string;
+  message?: string | undefined;
 }>();
 
 const trimmedMessage = computed(() => message?.trim() || undefined);

--- a/resources/js/Pages/Admin/Settings/Partials/UpdateGeneralSettingsForm.vue
+++ b/resources/js/Pages/Admin/Settings/Partials/UpdateGeneralSettingsForm.vue
@@ -18,6 +18,8 @@ const form = useForm({
   systemShiftEndHour: settings.systemShiftEndHour,
   enableUserAvailability: settings.enableUserAvailability,
   enableUserLocationChoices: settings.enableUserLocationChoices,
+  enableShiftRemoveConfirm: settings.enableShiftRemoveConfirm,
+  shiftRemoveConfirmMessage: settings.shiftRemoveConfirmMessage,
 });
 
 const toast = useToast();
@@ -145,6 +147,35 @@ const endHour = useTemplateRef<{ $el: HTMLElement }>("systemShiftEndHour");
             niche setting, you probably will <strong>not</strong> need to enable this feature.
           </em>
         </div>
+      </div>
+
+      <div class="col-span-6 flex items-center flex-wrap">
+        <PCheckbox binary
+                   input-id="enable-shift-remove-confirm"
+                   v-model="form.enableShiftRemoveConfirm"
+                   value="true"
+                   class="mr-3" />
+        <JetLabel for="enable-shift-remove-confirm" value="Show confirmation when removing a reservation" />
+        <JetInputError :message="form.errors.enableShiftRemoveConfirm" class="mt-2" />
+        <div class="col-span-2 ml-1 text-sm text-gray-600 dark:text-gray-300 w-full">
+          When enabled, volunteers will see a confirmation before they remove a reservation.
+        </div>
+      </div>
+
+      <div class="col-span-6 sm:col-span-4">
+        <JetLabel for="shift-remove-confirm-message"
+                  value="Remove reservation confirmation message"
+                  :form
+                  error-key="shiftRemoveConfirmMessage" />
+        <PTextarea id="shift-remove-confirm-message"
+                   v-model="form.shiftRemoveConfirmMessage"
+                   rows="3"
+                   maxlength="200"
+                   class="mt-1 block w-full" />
+        <div class="mt-1 ml-1 max-w-xl text-sm text-gray-600 dark:text-gray-300">
+          This message is shown to volunteers when they remove a reservation. Required when the confirmation is enabled. Maximum 200 characters.
+        </div>
+        <JetInputError :message="form.errors.shiftRemoveConfirmMessage" class="mt-2" />
       </div>
     </template>
 

--- a/resources/js/Pages/Components/Dashboard/CartReservation.vue
+++ b/resources/js/Pages/Components/Dashboard/CartReservation.vue
@@ -18,6 +18,8 @@ import type { ShiftItem as SelectedShift } from "@/Pages/Components/Dashboard/Sh
 const page = usePage();
 const toast = useToast();
 
+const shiftRemoveConfirmMessage = computed(() => page.props.shiftRemoveConfirmMessage);
+
 const user = computed(() => page.props.auth.user);
 const timezone = computed(() => usePage().props.shiftAvailability.timezone);
 
@@ -89,6 +91,31 @@ const toggleReservation = async (locationId: number, shiftId: number, toggleOn: 
     isLoading.value = false;
     reservationWatch.resume();
   }
+};
+
+const showRemoveReservationModal = ref(false);
+const pendingRemoval = ref<{ locationId: number; shiftId: number } | null>(null);
+
+const promptRemoveReservation = (locationId: number, shiftId: number) => {
+  if (!shiftRemoveConfirmMessage.value) {
+    void toggleReservation(locationId, shiftId, false);
+    return;
+  }
+
+  pendingRemoval.value = { locationId, shiftId };
+  showRemoveReservationModal.value = true;
+};
+
+const cancelRemoveReservation = () => {
+  showRemoveReservationModal.value = false;
+  pendingRemoval.value = null;
+};
+
+const confirmRemoveReservation = () => {
+  if (pendingRemoval.value) {
+    void toggleReservation(pendingRemoval.value.locationId, pendingRemoval.value.shiftId, false);
+  }
+  cancelRemoveReservation();
 };
 
 const locationsOnDates = ref<LocationsOnDate[]>([]);
@@ -347,8 +374,8 @@ debouncedWatch(locations, () => {
                       <button v-if="!isRestricted"
                               type="button"
                               class="block"
-                              @click="toggleReservation(location.id, shift.id, false)">
-                        <User status="reserved" v-tooltip="`${volunteer.name}: Tap to un-reserve this shift`" />
+                              @click="promptRemoveReservation(location.id, shift.id)">
+                        <User status="reserved" v-tooltip="`${volunteer.name}: Tap to remove your reservation from this shift`" />
                       </button>
                       <User status="reserved" v-else />
                     </template>
@@ -396,6 +423,17 @@ debouncedWatch(locations, () => {
       </Accordion>
     </ComponentSpinner>
   </div>
+  <PDialog v-model:visible="showRemoveReservationModal"
+           modal
+           header="Confirmation"
+           pt:root="w-[calc(100vw-2rem)] max-w-lg">
+    <p class="dark:text-gray-100">{{ shiftRemoveConfirmMessage }}</p>
+
+    <template #footer>
+      <PButton label="Cancel" severity="secondary" outlined @click="cancelRemoveReservation" />
+      <PButton label="Remove Reservation" @click="confirmRemoveReservation" />
+    </template>
+  </PDialog>
 </template>
 
 <!--suppress CssUnusedSymbol -->

--- a/resources/js/types/laravel-request-helpers.d.ts
+++ b/resources/js/types/laravel-request-helpers.d.ts
@@ -27,6 +27,7 @@ export type InertiaProps = {
   enableUserAvailability?: boolean;
   needsToUpdateAvailability?: boolean;
   enableUserLocationChoices?: boolean;
+  shiftRemoveConfirmMessage?: string;
   isUnrestricted?: true;
   auth: {
     user: AuthUser;

--- a/resources/js/types/laravel.d.ts
+++ b/resources/js/types/laravel.d.ts
@@ -230,5 +230,7 @@ declare namespace App.Settings {
     systemShiftEndHour: number;
     enableUserAvailability: boolean;
     enableUserLocationChoices: boolean;
+    enableShiftRemoveConfirm: boolean;
+    shiftRemoveConfirmMessage: string;
   };
 }

--- a/tests/Feature/App/Admin/GeneralSettingsTest.php
+++ b/tests/Feature/App/Admin/GeneralSettingsTest.php
@@ -31,6 +31,8 @@ class GeneralSettingsTest extends TestCase
         $generalSettings->systemShiftEndHour        = 13;
         $generalSettings->enableUserAvailability    = false;
         $generalSettings->enableUserLocationChoices = false;
+        $generalSettings->enableShiftRemoveConfirm  = false;
+        $generalSettings->shiftRemoveConfirmMessage = 'Have you contacted all others on your shift?';
         $generalSettings->save();
 
         $this->actingAs($admin)
@@ -40,6 +42,8 @@ class GeneralSettingsTest extends TestCase
                 'systemShiftEndHour'        => 15,
                 'enableUserAvailability'    => true,
                 'enableUserLocationChoices' => true,
+                'enableShiftRemoveConfirm'  => true,
+                'shiftRemoveConfirmMessage' => 'Custom confirmation message',
             ])
             ->assertRedirect(route('admin.settings'));
 
@@ -49,6 +53,43 @@ class GeneralSettingsTest extends TestCase
         $this->assertSame(15, $generalSettings->systemShiftEndHour);
         $this->assertTrue($generalSettings->enableUserAvailability);
         $this->assertTrue($generalSettings->enableUserLocationChoices);
+        $this->assertTrue($generalSettings->enableShiftRemoveConfirm);
+        $this->assertSame('Custom confirmation message', $generalSettings->shiftRemoveConfirmMessage);
+    }
+
+    public function test_remove_reservation_confirmation_message_is_not_required_when_confirmation_disabled(): void
+    {
+        $admin = User::factory()->adminRoleUser()->create();
+
+        $this->actingAs($admin)
+            ->putJson('/admin/general-settings', [
+                'siteName'                  => 'Site Name',
+                'systemShiftStartHour'      => 8,
+                'systemShiftEndHour'        => 17,
+                'enableUserAvailability'    => false,
+                'enableUserLocationChoices' => false,
+                'enableShiftRemoveConfirm'  => false,
+                'shiftRemoveConfirmMessage' => '',
+            ])
+            ->assertRedirect(route('admin.settings'));
+    }
+
+    public function test_remove_reservation_confirmation_message_is_required_when_confirmation_enabled(): void
+    {
+        $admin = User::factory()->adminRoleUser()->create();
+
+        $this->actingAs($admin)
+            ->putJson('/admin/general-settings', [
+                'siteName'                  => 'Site Name',
+                'systemShiftStartHour'      => 8,
+                'systemShiftEndHour'        => 17,
+                'enableUserAvailability'    => false,
+                'enableUserLocationChoices' => false,
+                'enableShiftRemoveConfirm'  => true,
+                'shiftRemoveConfirmMessage' => '',
+            ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['shiftRemoveConfirmMessage']);
     }
 
     public function test_admin_can_update_allowed_settings_users(): void
@@ -81,6 +122,8 @@ class GeneralSettingsTest extends TestCase
         $generalSettings->systemShiftEndHour        = 13;
         $generalSettings->enableUserAvailability    = false;
         $generalSettings->enableUserLocationChoices = false;
+        $generalSettings->enableShiftRemoveConfirm  = true;
+        $generalSettings->shiftRemoveConfirmMessage = 'Have you contacted all others on your shift?';
         $generalSettings->currentVersion            = '1.0.0';
         $generalSettings->availableVersion          = '1.0.1';
         $generalSettings->allowedSettingsUsers      = [$admin->getKey()];
@@ -96,6 +139,8 @@ class GeneralSettingsTest extends TestCase
                     ->where('systemShiftEndHour', 13)
                     ->where('enableUserAvailability', false)
                     ->where('enableUserLocationChoices', false)
+                    ->where('enableShiftRemoveConfirm', true)
+                    ->where('shiftRemoveConfirmMessage', 'Have you contacted all others on your shift?')
                     ->where('currentVersion', '1.0.0')
                     ->where('availableVersion', '1.0.1')
                     ->where('allowedSettingsUsers', [$admin->getKey()])


### PR DESCRIPTION
Optional confirmation dialog shown to volunteers when they remove a shift reservation. 
Admins can enable the feature and set a custom message via site settings.

- Add enableShiftRemoveConfirm and shiftRemoveConfirmMessage settings with a settings migration
- Validate the message as required when the confirmation is enabled (max 200 chars) and cast booleans in the controller
- Share the message with the frontend via Inertia middleware
- Add admin settings form fields and a confirmation modal in CartReservation
- Update TypeScript types and add feature test coverage