### PR TITLE
fix(dashboard) 

### DIFF
--- a/resources/js/Pages/Admin/Dashboard/UserTable.vue
+++ b/resources/js/Pages/Admin/Dashboard/UserTable.vue
@@ -9,6 +9,7 @@ import useToast from "@/Composables/useToast";
 import FilledShiftsIndicator from "@/Pages/Admin/Dashboard/FilledShiftsIndicator.vue";
 import { useGlobalState } from "@/store";
 import { EnableUserAvailability } from "@/Utils/provide-inject-keys";
+import { calcShiftPercentage, capFilledForDay } from "@/Utils/volunteerAvailability";
 import type { AssignVolunteerPayload } from "@/types/types";
 
 const props = defineProps({
@@ -172,13 +173,13 @@ const tableRows = computed(() => {
       saturday: volunteer.num_saturdays,
     };
     const daysAlreadyRostered = {
-      sunday: (volunteer.filled_sundays < daysAvailable.sunday ? volunteer.filled_sundays : daysAvailable.sunday) || 0,
-      monday: (volunteer.filled_mondays < daysAvailable.monday ? volunteer.filled_mondays : daysAvailable.monday) || 0,
-      tuesday: (volunteer.filled_tuesdays < daysAvailable.tuesday ? volunteer.filled_tuesdays : daysAvailable.tuesday) || 0,
-      wednesday: (volunteer.filled_wednesdays < daysAvailable.wednesday ? volunteer.filled_wednesdays : daysAvailable.wednesday) || 0,
-      thursday: (volunteer.filled_thursdays < daysAvailable.thursday ? volunteer.filled_thursdays : daysAvailable.thursday) || 0,
-      friday: (volunteer.filled_fridays < daysAvailable.friday ? volunteer.filled_fridays : daysAvailable.friday) || 0,
-      saturday: (volunteer.filled_saturdays < daysAvailable.saturday ? volunteer.filled_saturdays : daysAvailable.saturday) || 0,
+      sunday: capFilledForDay(volunteer.filled_sundays, daysAvailable.sunday),
+      monday: capFilledForDay(volunteer.filled_mondays, daysAvailable.monday),
+      tuesday: capFilledForDay(volunteer.filled_tuesdays, daysAvailable.tuesday),
+      wednesday: capFilledForDay(volunteer.filled_wednesdays, daysAvailable.wednesday),
+      thursday: capFilledForDay(volunteer.filled_thursdays, daysAvailable.thursday),
+      friday: capFilledForDay(volunteer.filled_fridays, daysAvailable.friday),
+      saturday: capFilledForDay(volunteer.filled_saturdays, daysAvailable.saturday),
     };
 
     const numDaysKey = `num_${shiftDayKey.value}s` as keyof App.Data.ExtendedUserData;
@@ -205,29 +206,6 @@ const tableRows = computed(() => {
     };
   });
 });
-
-const calcShiftPercentage = (daysRostered, daysAvailable) => {
-  if (!daysAvailable) {
-    return 0;
-  }
-  let sumOfDaysRostered = 0;
-  let sumOfDaysAvailable = 0;
-  for (const day in daysAvailable) {
-    if (!Object.hasOwn(daysAvailable, day) || !daysAvailable[day]) {
-      continue;
-    }
-    // Not using Array.reduce because we're only calculating based on the days a volunteer is available
-    sumOfDaysRostered += daysRostered[day];
-    sumOfDaysAvailable += daysAvailable[day];
-    if (sumOfDaysRostered > sumOfDaysAvailable) {
-      sumOfDaysRostered = sumOfDaysAvailable;
-    }
-  }
-  if (sumOfDaysAvailable === 0) {
-    return 0;
-  }
-  return Math.round((sumOfDaysRostered / sumOfDaysAvailable) * 100);
-};
 
 const assignVolunteer = (volunteerId, volunteerName) => {
   emit("assignVolunteer", { volunteerId, volunteerName, location: props.location, shift: props.shift });

--- a/resources/js/Utils/volunteerAvailability.ts
+++ b/resources/js/Utils/volunteerAvailability.ts
@@ -1,0 +1,37 @@
+export type DayAvailability = Record<string, number>;
+
+export const capFilledForDay = (
+  filled: number | null | undefined,
+  available: number | null | undefined,
+): number => Math.min(filled ?? 0, available ?? 0);
+
+export const calcShiftPercentage = (
+  daysRostered: DayAvailability,
+  daysAvailable: DayAvailability,
+): number => {
+  if (!daysAvailable) {
+    return 0;
+  }
+
+  let sumOfDaysRostered = 0;
+  let sumOfDaysAvailable = 0;
+
+  for (const day in daysAvailable) {
+    if (!Object.hasOwn(daysAvailable, day) || !daysAvailable[day]) {
+      continue;
+    }
+
+    sumOfDaysRostered += daysRostered[day];
+    sumOfDaysAvailable += daysAvailable[day];
+
+    if (sumOfDaysRostered > sumOfDaysAvailable) {
+      sumOfDaysRostered = sumOfDaysAvailable;
+    }
+  }
+
+  if (sumOfDaysAvailable === 0) {
+    return 0;
+  }
+
+  return Math.round((sumOfDaysRostered / sumOfDaysAvailable) * 100);
+};

--- a/resources/js/__tests__/utils/volunteerAvailability.test.ts
+++ b/resources/js/__tests__/utils/volunteerAvailability.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { calcShiftPercentage, capFilledForDay } from "@/Utils/volunteerAvailability";
+
+describe("capFilledForDay", () => {
+  it("treats missing filled counts as zero", () => {
+    expect(capFilledForDay(undefined, 3)).toBe(0);
+    expect(capFilledForDay(null, 3)).toBe(0);
+  });
+
+  it("caps filled counts at the available amount", () => {
+    expect(capFilledForDay(2, 3)).toBe(2);
+    expect(capFilledForDay(4, 3)).toBe(3);
+  });
+});
+
+describe("calcShiftPercentage", () => {
+  it("returns zero when no shifts have been rostered", () => {
+    const daysAvailable = {
+      sunday: 0,
+      monday: 1,
+      tuesday: 0,
+      wednesday: 0,
+      thursday: 2,
+      friday: 0,
+      saturday: 0,
+    };
+    const daysAlreadyRostered = {
+      sunday: 0,
+      monday: 0,
+      tuesday: 0,
+      wednesday: 0,
+      thursday: 0,
+      friday: 0,
+      saturday: 0,
+    };
+
+    expect(calcShiftPercentage(daysAlreadyRostered, daysAvailable)).toBe(0);
+  });
+
+  it("calculates partial rostering correctly", () => {
+    const daysAvailable = {
+      sunday: 0,
+      monday: 0,
+      tuesday: 3,
+      wednesday: 0,
+      thursday: 0,
+      friday: 1,
+      saturday: 4,
+    };
+    const daysAlreadyRostered = {
+      sunday: 0,
+      monday: 0,
+      tuesday: 2,
+      wednesday: 0,
+      thursday: 0,
+      friday: 0,
+      saturday: 3,
+    };
+
+    expect(calcShiftPercentage(daysAlreadyRostered, daysAvailable)).toBe(62);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a bug where volunteer availability showed **100%** in the assign-volunteer modal for future months (e.g. October onwards) when no one had been rostered yet.

When a volunteer has no shifts in the selected month, the API omits `filled_*` fields from the response (`null` in the database). The old frontend logic treated `undefined` as fully rostered because `undefined < n` is `false` in JavaScript, so it fell through to the available count instead of zero.

This change treats missing filled counts as `0` via `capFilledForDay()`, and extracts the availability calculation into a testable util.

## Test plan

- [ ] Open the admin dashboard and select a date in a future month with no rostered shifts (e.g. October 2026)
- [ ] Open the assign-volunteer modal for a shift
- [ ] Confirm volunteers with availability set but no shifts that month show **0%**, not 100%
- [ ] Assign a volunteer to one shift in that month and reopen the modal — percentage should update correctly (e.g. partial %)
- [ ] Check a current/past month with existing rostering still shows correct percentages
- [ ] Run `vendor/bin/sail npm run test -- resources/js/__tests__/utils/volunteerAvailability.test.ts`