### PR TITLE
refactor(exports)

### DIFF
--- a/resources/js/Components/Form/DateRange.vue
+++ b/resources/js/Components/Form/DateRange.vue
@@ -4,12 +4,19 @@ import { computed, watch, ref, useId } from "vue";
 import JetInputError from "@/Jetstream/InputError.vue";
 import JetLabel from "@/Jetstream/Label.vue";
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   startDate?: string;
   endDate?: string;
   startError?: string;
   endError?: string;
-}>();
+  /** When true, dates before today can be selected (e.g. export date ranges). */
+  allowPastDates?: boolean;
+  /** When true, the end date may match the start date (e.g. single-day exports). */
+  allowSameDayEnd?: boolean;
+}>(), {
+  allowPastDates: false,
+  allowSameDayEnd: false,
+});
 
 const emit = defineEmits([
   "update:startDate",
@@ -46,9 +53,15 @@ watch(end, (value) => {
   }
 });
 
-const minDate = computed(() => start.value
-  ? addDays(start.value, 1)
-  : addDays(new Date(), 1));
+const startMinDate = computed(() => props.allowPastDates ? undefined : new Date());
+
+const endMinDate = computed(() => {
+  if (start.value) {
+    return props.allowSameDayEnd ? start.value : addDays(start.value, 1);
+  }
+
+  return props.allowPastDates ? undefined : addDays(new Date(), 1);
+});
 
 const maxDate = computed(() => end.value
   ? end.value
@@ -64,7 +77,7 @@ const id = useId();
 
       <PDatePicker :input-id="`${id}-start`"
                    v-model="start"
-                   :minDate="new Date()"
+                   :minDate="startMinDate"
                    :maxDate
                    :dateFormat="fieldFormat"
                    input-class="w-full"/>
@@ -75,7 +88,7 @@ const id = useId();
 
       <PDatePicker :input-id="`${id}-end`"
                    v-model="end"
-                   :minDate
+                   :minDate="endMinDate"
                    :dateFormat="fieldFormat"
                    input-class="w-full"/>
       <JetInputError :message="endError" />

--- a/resources/js/Pages/Admin/Exports/Show.vue
+++ b/resources/js/Pages/Admin/Exports/Show.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
 import { computed, ref } from "vue";
 import JetHelpText from "@/Jetstream/HelpText.vue";
-import JetInput from "@/Jetstream/Input.vue";
 import JetLabel from "@/Jetstream/Label.vue";
-import JetSecondaryButton from "@/Jetstream/SecondaryButton.vue";
+import DateRange from "@/Components/Form/DateRange.vue";
 
 type Export = {
   routeName:
@@ -67,45 +66,35 @@ const download = (exportItem: Export) => {
   <PageHeader title="Exports">
     <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">Exports</h2>
   </PageHeader>
-  <div class="max-w-7xl mx-auto pt-10 pb-5 sm:px-6 lg:px-8">
-    <div class="bg-white dark:bg-slate-900 shadow-xl sm:rounded-lg p-6 space-y-8">
-      <div>
-        <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-200">Date range</h3>
-        <JetHelpText class="mt-1">
-          Required for reports, shift assignment, and shift count exports.
-        </JetHelpText>
+  <div class="flex flex-col gap-4">
+    <div class="bg-panel dark:bg-panel-dark border border-neutral-300/75 dark:border-neutral-800 sm:rounded-lg sm:p-6">
+      <JetLabel value="Date range"/>
+      <JetHelpText class="mt-1">
+        Required for reports, shift assignment, and shift count exports.
+      </JetHelpText>
 
-        <div class="mt-4 grid gap-4 sm:grid-cols-2 max-w-xl">
-          <div>
-            <JetLabel for="start_date" value="Start date"/>
-            <JetInput id="start_date"
-                      v-model="startDate"
-                      class="mt-1 block w-full"
-                      type="date"/>
-          </div>
-          <div>
-            <JetLabel for="end_date" value="End date"/>
-            <JetInput id="end_date"
-                      v-model="endDate"
-                      class="mt-1 block w-full"
-                      type="date"/>
-          </div>
-        </div>
-      </div>
+      <DateRange v-model:start-date="startDate"
+                         v-model:end-date="endDate"
+                         allow-past-dates
+                         allow-same-day-end
+                         class="mt-4 max-w-xl"/>
+    </div>
 
-      <div class="space-y-4">
-        <div v-for="exportItem in EXPORTS"
-             :key="exportItem.routeName"
-             class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 border-t border-gray-200 dark:border-gray-700 pt-6">
-          <div>
-            <h3 class="font-medium text-gray-900 dark:text-gray-200">{{ exportItem.title }}</h3>
-            <JetHelpText>{{ exportItem.description }}</JetHelpText>
-          </div>
-          <JetSecondaryButton :disabled="!isAvailable(exportItem)"
-                              @click="download(exportItem)">
-            Download CSV
-          </JetSecondaryButton>
+    <div class="bg-panel dark:bg-panel-dark border border-neutral-300/75 dark:border-neutral-800 sm:rounded-lg sm:p-6">
+      <div v-for="(exportItem, index) in EXPORTS"
+           :key="exportItem.routeName"
+           class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3"
+           :class="{ 'border-t border-neutral-300/75 dark:border-neutral-800 pt-6 mt-6': index > 0 }">
+        <div>
+          <h3 class="font-medium text-gray-900 dark:text-gray-200">{{ exportItem.title }}</h3>
+          <JetHelpText>{{ exportItem.description }}</JetHelpText>
         </div>
+        <PButton label="Download CSV"
+                 icon="iconify mdi--download"
+                 severity="info"
+                 variant="outlined"
+                 :disabled="!isAvailable(exportItem)"
+                 @click="download(exportItem)" />
       </div>
     </div>
   </div>

--- a/resources/js/Pages/Profile/Partials/ShowVacationsAvailabilityForm.vue
+++ b/resources/js/Pages/Profile/Partials/ShowVacationsAvailabilityForm.vue
@@ -9,7 +9,7 @@ import JetActionMessage from "@/Jetstream/ActionMessage.vue";
 import JetFormSection from "@/Jetstream/FormSection.vue";
 import JetInput from "@/Jetstream/Input.vue";
 import JetInputError from "@/Jetstream/InputError.vue";
-import VacationDateRange from "@/Pages/Profile/Partials/VacationDateRange.vue";
+import DateRange from "@/Components/Form/DateRange.vue";
 import precognitiveForm from "@/Utils/precognitiveForm";
 
 const { vacations = [], userId } = defineProps<{
@@ -84,7 +84,7 @@ const deleteVacation = (idx: number) => form.deletedVacations = [...form.deleted
                      @click="deleteVacation(idx)">
               <CloseCircle />
             </PButton>
-            <vacation-date-range v-model:start-date="vacation.start_date"
+            <DateRange v-model:start-date="vacation.start_date"
                                  v-model:end-date="vacation.end_date"
                                  :start-error="form.errors[`vacations.${idx}.start_date`]"
                                  :end-error="form.errors[`vacations.${idx}.end_date`]" />

--- a/resources/js/__tests__/components/DateRange.test.ts
+++ b/resources/js/__tests__/components/DateRange.test.ts
@@ -1,0 +1,156 @@
+import { fireEvent, render, screen } from "@testing-library/vue";
+import { addDays, formatISO } from "date-fns";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { defineComponent } from "vue";
+import DateRange from "@/Components/Form/DateRange.vue";
+
+const today = new Date("2026-03-15T12:00:00");
+
+const toDateKey = (date?: Date) => (date ? formatISO(date, { representation: "date" }) : "none");
+
+const PDatePickerStub = defineComponent({
+  name: "PDatePicker",
+  props: {
+    inputId: { type: String, required: true },
+    minDate: { type: Date, required: false },
+    maxDate: { type: Date, required: false },
+    modelValue: { type: Date, required: false },
+  },
+  emits: ["update:modelValue"],
+  setup(props) {
+    const dateKey = (date?: Date) => toDateKey(date);
+
+    return { dateKey, props };
+  },
+  template: `
+    <input
+      :id="props.inputId"
+      type="text"
+      :data-min="dateKey(props.minDate)"
+      :data-max="dateKey(props.maxDate)"
+      :value="dateKey(props.modelValue)"
+      @change="$emit('update:modelValue', new Date($event.target.value + 'T12:00:00'))"
+    />
+  `,
+});
+
+const stubs = {
+  PDatePicker: PDatePickerStub,
+  JetLabel: {
+    props: ["value", "hasError"],
+    template: "<span>{{ value }}</span>",
+  },
+  JetInputError: {
+    props: ["message"],
+    template: "<span v-if=\"message\">{{ message }}</span>",
+  },
+};
+
+const renderDateRange = (props: Record<string, unknown> = {}) => render(DateRange, {
+  props,
+  global: { stubs },
+});
+
+const picker = (container: Element, field: "start" | "end") =>
+  container.querySelector(`[id$="-${field}"]`) as HTMLInputElement;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(today);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("DateRange", () => {
+  it("renders From and To labels", () => {
+    renderDateRange();
+
+    expect(screen.getByText("From")).toBeTruthy();
+    expect(screen.getByText("To")).toBeTruthy();
+  });
+
+  it("shows validation errors when provided", () => {
+    renderDateRange({
+      startError: "Start is required.",
+      endError: "End is required.",
+    });
+
+    expect(screen.getByText("Start is required.")).toBeTruthy();
+    expect(screen.getByText("End is required.")).toBeTruthy();
+  });
+
+  describe("vacation defaults", () => {
+    it("only allows future start dates", () => {
+      const { container } = renderDateRange();
+
+      expect(picker(container, "start").dataset.min).toBe(toDateKey(today));
+    });
+
+    it("requires the end date to be at least one day after the start", () => {
+      const { container } = renderDateRange({ startDate: "2026-04-01" });
+
+      expect(picker(container, "end").dataset.min).toBe(
+        toDateKey(addDays(new Date("2026-04-01T12:00:00"), 1)),
+      );
+    });
+
+    it("requires a future end date before a start date is chosen", () => {
+      const { container } = renderDateRange();
+
+      expect(picker(container, "end").dataset.min).toBe(
+        toDateKey(addDays(today, 1)),
+      );
+    });
+
+    it("caps the start date at the chosen end date", () => {
+      const { container } = renderDateRange({ endDate: "2026-04-30" });
+
+      expect(picker(container, "start").dataset.max).toBe("2026-04-30");
+    });
+  });
+
+  describe("export options", () => {
+    it("allows historical start dates", () => {
+      const { container } = renderDateRange({ allowPastDates: true });
+
+      expect(picker(container, "start").dataset.min).toBe("none");
+    });
+
+    it("allows the end date to match the start date", () => {
+      const { container } = renderDateRange({
+        allowPastDates: true,
+        allowSameDayEnd: true,
+        startDate: "2026-01-01",
+      });
+
+      expect(picker(container, "end").dataset.min).toBe("2026-01-01");
+    });
+
+    it("does not require a future end date before a start date is chosen", () => {
+      const { container } = renderDateRange({ allowPastDates: true });
+
+      expect(picker(container, "end").dataset.min).toBe("none");
+    });
+  });
+
+  it("emits ISO date strings when dates are selected", async () => {
+    const onStartDate = vi.fn();
+    const onEndDate = vi.fn();
+
+    const { container } = render(DateRange, {
+      props: {
+        "onUpdate:startDate": onStartDate,
+        "onUpdate:endDate": onEndDate,
+      },
+      global: { stubs },
+    });
+
+    await fireEvent.change(picker(container, "start"), { target: { value: "2026-01-01" } });
+    await fireEvent.change(picker(container, "end"), { target: { value: "2026-01-31" } });
+
+    expect(onStartDate).toHaveBeenCalledWith("2026-01-01");
+    expect(onEndDate).toHaveBeenCalledWith("2026-01-31");
+  });
+});

--- a/resources/js/__tests__/components/ExportsPage.test.ts
+++ b/resources/js/__tests__/components/ExportsPage.test.ts
@@ -4,11 +4,15 @@ import Show from "@/Pages/Admin/Exports/Show.vue";
 
 const stubs = {
   PageHeader: { template: "<div><slot /></div>" },
-  /** The real one wraps PrimeVue's input, which is auto-imported and absent here. */
-  JetInput: {
-    props: ["modelValue"],
-    emits: ["update:modelValue"],
-    template: "<input :value=\"modelValue\" @input=\"$emit('update:modelValue', $event.target.value)\" />",
+  DateRange: {
+    props: ["startDate", "endDate"],
+    emits: ["update:startDate", "update:endDate"],
+    template: `
+      <div>
+        <input aria-label="From" :value="startDate" @input="$emit('update:startDate', $event.target.value)" />
+        <input aria-label="To" :value="endDate" @input="$emit('update:endDate', $event.target.value)" />
+      </div>
+    `,
   },
 };
 
@@ -31,8 +35,8 @@ const downloadButtonFor = (title: string) => {
 };
 
 const setDateRange = async () => {
-  await fireEvent.update(screen.getByLabelText("Start date"), "2026-01-01");
-  await fireEvent.update(screen.getByLabelText("End date"), "2026-01-31");
+  await fireEvent.update(screen.getByLabelText("From"), "2026-01-01");
+  await fireEvent.update(screen.getByLabelText("To"), "2026-01-31");
 };
 
 beforeEach(() => {

--- a/resources/js/__tests__/components/ExportsPage.test.ts
+++ b/resources/js/__tests__/components/ExportsPage.test.ts
@@ -4,11 +4,25 @@ import Show from "@/Pages/Admin/Exports/Show.vue";
 
 const stubs = {
   PageHeader: { template: "<div><slot /></div>" },
+  PButton: {
+    props: ["label", "disabled"],
+    emits: ["click"],
+    template: "<button :disabled=\"disabled\" @click=\"$emit('click')\">{{ label }}</button>",
+  },
   DateRange: {
-    props: ["startDate", "endDate"],
+    props: {
+      startDate: { type: String, required: false },
+      endDate: { type: String, required: false },
+      allowPastDates: { type: [Boolean, String], default: false },
+      allowSameDayEnd: { type: [Boolean, String], default: false },
+    },
     emits: ["update:startDate", "update:endDate"],
     template: `
-      <div>
+      <div
+        data-testid="date-range"
+        :data-allow-past-dates="allowPastDates === true || allowPastDates === '' ? 'true' : 'false'"
+        :data-allow-same-day-end="allowSameDayEnd === true || allowSameDayEnd === '' ? 'true' : 'false'"
+      >
         <input aria-label="From" :value="startDate" @input="$emit('update:startDate', $event.target.value)" />
         <input aria-label="To" :value="endDate" @input="$emit('update:endDate', $event.target.value)" />
       </div>
@@ -64,6 +78,14 @@ describe("Exports page", () => {
     for (const title of ["Reports", "Shift assignments", "Shift counts", "User availabilities"]) {
       expect(screen.getByRole("heading", { name: title })).toBeTruthy();
     }
+  });
+
+  it("uses the shared date range picker with export-friendly constraints", () => {
+    const { getByTestId } = renderExports();
+    const dateRange = getByTestId("date-range");
+
+    expect(dateRange.getAttribute("data-allow-past-dates")).toBe("true");
+    expect(dateRange.getAttribute("data-allow-same-day-end")).toBe("true");
   });
 
   it("holds back the date-range exports until there is a date range", async () => {

--- a/resources/js/types/auto-import-components.d.ts
+++ b/resources/js/types/auto-import-components.d.ts
@@ -27,6 +27,7 @@ declare module 'vue' {
     DangerButton: typeof import('./../Components/Form/Buttons/DangerButton.vue')['default']
     DarkMode: typeof import('./../Layouts/Components/DarkMode.vue')['default']
     DataTable: typeof import('./../Components/DataTable.vue')['default']
+    DateRange: typeof import('./../Components/Form/DateRange.vue')['default']
     Dialog: typeof import('./../Components/Dialog.vue')['default']
     DragDrop: typeof import('./../Components/Icons/DragDrop.vue')['default']
     EmptySlot: typeof import('./../Components/Icons/EmptySlot.vue')['default']


### PR DESCRIPTION
## Summary

Aligns `/admin/exports` with the rest of the admin UI and reuses the same date range picker as the vacations section on `/user/availability`.

- Extracts `VacationDateRange` into a shared `DateRange` component at `Components/Form/DateRange.vue`
- Uses `DateRange` on the exports page instead of native `<input type="date">` fields
- Updates exports page layout to match other admin pages (`bg-panel` panels, outlined `PButton` download buttons)
- Adds `allowPastDates` and `allowSameDayEnd` props so exports can select historical ranges and single-day periods, while vacation behaviour stays unchanged

## Test plan

- [ ] Visit `/admin/exports` and confirm the page matches the styling of other admin pages (Reports, Users)
- [ ] Select a date range using the From/To pickers and download each CSV export that requires a range
- [ ] Confirm single-day exports work when start and end dates are the same
- [ ] Confirm past dates can be selected for exports
- [ ] Visit `/user/availability` and confirm vacation date picking still works as before (future dates only, end date at least one day after start)
- [ ] Run `vendor/bin/sail npm run test -- resources/js/__tests__/components/ExportsPage.test.ts`